### PR TITLE
T85: Remove all references to goshawk version numbers from the JS Client API

### DIFF
--- a/example/env/config.json
+++ b/example/env/config.json
@@ -1,6 +1,6 @@
 {
     "ClusterId": "myCluster",
-    "Version": 1,
+    "Version": 22,
     "Hosts": [
         "localhost"
     ],
@@ -9,6 +9,10 @@
     "ClientCertificateFingerprints": {
         "6c5b2b2efc0ef77248af64cda16445fdfe936c9f5484711d77c9d67bba5dfe44": {
             "test": {
+              "Read": true,
+              "Write": true
+            },
+	        "myRoot": {
               "Read": true,
               "Write": true
             }

--- a/example/env/config.json
+++ b/example/env/config.json
@@ -1,6 +1,6 @@
 {
     "ClusterId": "myCluster",
-    "Version": 22,
+    "Version": 1,
     "Hosts": [
         "localhost"
     ],

--- a/example/env/config.json
+++ b/example/env/config.json
@@ -12,7 +12,7 @@
               "Read": true,
               "Write": true
             },
-	        "myRoot": {
+            "myRoot": {
               "Read": true,
               "Write": true
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goshawkdb",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A javascript client for goshawkdb.",
   "main": "./index.js",
   "scripts": {

--- a/src/connection.js
+++ b/src/connection.js
@@ -128,27 +128,16 @@ class Connection {
 	 * run multiple times and so should avoid side effects.
 	 * fn may be an asynchronous or a synchronous function.
 	 *
-	 * @param {function(txn: Transaction): {*|Promise<*, Error>}} fn the transaction function.  This function may be run multiple times and should rethrow any TransactionRetryNeeded exceptions.
-	 * @param {function(result: *, meta: *): *} onCommit a callback function that returns the result.  This fires when the
-	 * 						changes in the transaction have been committed to the database.  You could also use the returned promise.
-	 * @returns {Promise<*, Error>} a promise that resolves to the result of the transaction function once the transaction submits or an error if it cannot.
+	 * @param {function(txn:Transaction):{*|Promise<*,Error>}} txnFn the transaction function.  This function may be run multiple times and should rethrow any TransactionRetryNeeded exceptions.
+	 * @returns {Promise<*,Error>} a promise that resolves to the result of the transaction function once the transaction submits or an error if it cannot.
  	 */
-	transact(fn, onCommit) {
-		if (fn instanceof Function === false) {
-			throw new TypeError(`Connection ${this.connectionId}: Transaction argument must be a function, was ${String(fn)}`)
+	transact(txnFn) {
+		if (txnFn instanceof Function === false) {
+			throw new TypeError(`Connection ${this.connectionId}: Transaction argument must be a function, was ${String(txnFn)}`)
 		}
 
 		return new Promise((resolve, reject) => {
-			this.transactions.push(new Transaction(fn, {onSuccess: (id, result) => {
-				if (onCommit) {
-					try {
-						onCommit(result, {id})
-					} catch (e) {
-						console.error("Transaction committed: failure during onCommit callback execution.", e)
-					}
-				}
-				resolve(result)
-			}, onFail: reject}, this.roots, this.namespace, this.cache))
+			this.transactions.push(new Transaction(txnFn, {onSuccess: resolve, onFail: reject}, this.roots, this.namespace, this.cache))
 			this.scheduleNextTransaction(false)
 		})
 	}
@@ -178,7 +167,7 @@ class Connection {
 			if (finalId) {
 				currentTransaction.promoteCache(finalId)
 			}
-			currentTransaction.onSuccess(finalId, transactionResult)
+			currentTransaction.onSuccess(transactionResult)
 			this.scheduleNextTransaction(true)
 		}
 		const retry = () => {

--- a/src/objectcache.js
+++ b/src/objectcache.js
@@ -88,14 +88,6 @@ class ObjectCacheEntry {
 							return srcRefs.slice()
 						}
 					}
-				},
-				version: {
-					set: () => {
-						throw new MutationNotAllowed("Cannot set references without a transaction.write call.")
-					},
-					get: () => {
-						return this.version
-					}
 				}
 			})
 

--- a/src/ref.js
+++ b/src/ref.js
@@ -18,7 +18,6 @@ class Ref {
 
 		/**
 		 * The goshawkdb id of the object this reference refers to.
-		 * @private
 		 */
 		this.varId = varId
 
@@ -34,12 +33,10 @@ class Ref {
 		this.write = write
 	}
 
-	/** @private */
 	static fromCapRef(capability, varId) {
 		return new Ref(varId, capability.Read, capability.Write)
 	}
 
-	/** @private */
 	static fromMessage(msg) {
 		return Ref.fromCapRef(msg.Capability, msg.VarId)
 	}
@@ -73,7 +70,6 @@ class Ref {
 		return `{Ref ${binaryToHex(this.varId)} ${this.read ? 'r' : '-'}${this.write ? 'w' : '-'}}`
 	}
 
-	/** @private */
 	toMessage() {
 		return {VarId: this.varId.buffer, Capability: {Read: this.read, Write: this.write}}
 	}

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -76,6 +76,23 @@ function setupThenTransactionTest(setup, test) {
 	}
 }
 
+function connectionTest(test) {
+	return (t) => {
+		return new Promise((resolve, reject) => {
+			goshawkdb
+				.connect(`wss://${connectionOptions.host}:${connectionOptions.port}/ws`, connectionOptions)
+				.then((conn) => {
+					try {
+						return Promise.resolve(test(t, conn))
+					} catch (e) {
+						return Promise.reject(e)
+					}
+				}).then(resolve, reject)
+		})
+	}
+}
+
+exports.connectionTest = connectionTest
 exports.connectionOptions = connectionOptions
 exports.testRootName = connectionOptions.root
 exports.setupThenTransactionTest = setupThenTransactionTest

--- a/test/unit/ref.test.js
+++ b/test/unit/ref.test.js
@@ -1,0 +1,14 @@
+const test = require('ava')
+const Ref = require('../../src/ref')
+
+test("Check that I can increment a Uint64 loaded from a buffer", (t) => {
+	const ref1 = Ref.fromMessage({VarId: Uint8Array.from([1, 2, 3]), Capability: {Read: true, Write: false}})
+	const ref2 = Ref.fromMessage({VarId: Uint8Array.from([1, 2, 3]), Capability: {Read: true, Write: false}})
+	const ref3 = Ref.fromMessage({VarId: Uint8Array.from([1, 9, 3]), Capability: {Read: true, Write: false}})
+	const ref4 = Ref.fromMessage({VarId: Uint8Array.from([1, 2, 3]), Capability: {Read: false, Write: true}})
+
+	t.true(ref1.sameReferent(ref2))
+	t.true(ref2.sameReferent(ref1))
+	t.true(!ref1.sameReferent(ref3))
+	t.true(ref1.sameReferent(ref4))
+})


### PR DESCRIPTION
* Remove all references to goshawk version numbers from the JS Client API
* Add a root for sparrowhawk to the default environment
* Add tests for Ref functions to avoid coverage warnings
* Bump to 0.2.3